### PR TITLE
Make compatible with ember-modifier 4.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
   pull_request: {}
 
 concurrency:
-   group: ci-${{ github.head_ref || github.ref }}
-   cancel-in-progress: true
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -23,14 +23,18 @@ jobs:
         with:
           node-version: 14.x
           cache: yarn
+
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
+
       - name: Lint Addon
         run: yarn lint
         working-directory: addon
+
       - name: Lint Test App
         run: yarn lint
         working-directory: test-app
+
       - name: Run Tests
         run: yarn test:ember
         working-directory: test-app
@@ -46,8 +50,10 @@ jobs:
         with:
           node-version: 14.x
           cache: yarn
+
       - name: Install Dependencies
         run: yarn install --no-lockfile
+
       - name: Run Tests
         run: yarn test:ember
         working-directory: test-app
@@ -100,8 +106,44 @@ jobs:
         with:
           node-version: 14.x
           cache: yarn
+
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
+
       - name: Run Tests
         run: ./node_modules/.bin/ember try:one ${{ matrix.try-scenario }}
+        working-directory: test-app
+
+  ember-modifier-scenarios:
+    name: ${{ matrix.ember-modifier-scenario }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: 'test'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ember-modifier-scenario:
+          - ember-modifier@2
+          - ember-modifier@3.1
+          - ember-modifier@3.2
+          - ember-modifier@^4.0.0-beta.1
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14.x # ember-modifier 4.x requires Node.js 14
+          cache: yarn
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Update ember-modifier version
+        run: yarn add -D ${{ matrix.ember-modifier-scenario }}
+        working-directory: addon
+
+      - name: Run Tests
+        run: yarn test:ember
         working-directory: test-app

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,7 +13,7 @@ have been merged since the last release have been labeled with the appropriate
 represent something that would make sense to our users. Some great information
 on why this is important can be found at
 [keepachangelog.com](https://keepachangelog.com/en/1.0.0/), but the overall
-guiding principle here is that changelogs are for humans, not machines.
+guiding principles here is that changelogs are for humans, not machines.
 
 When reviewing merged PR's the labels to be used are:
 

--- a/addon/package.json
+++ b/addon/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.5.0",
-    "ember-modifier": "^2.1.2 || ^3.1.0"
+    "ember-modifier": "^2.1.2 || ^3.1.0 || ^4.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.17.9",

--- a/addon/src/modifiers/css-transition.js
+++ b/addon/src/modifiers/css-transition.js
@@ -1,309 +1,631 @@
 import Modifier from 'ember-modifier';
+import { registerDestructor } from '@ember/destroyable';
+import { macroCondition, dependencySatisfies } from '@embroider/macros';
 
 import { nextTick, sleep, computeTimeout } from '../utils/transition-utils';
 
-/**
-  Modifier that applies classes. Usage:
+let modifier;
 
-  ```hbs
-  <div {{css-transition name="example"}}>
+if (macroCondition(dependencySatisfies('ember-modifier', '>=3.2.0 || 4.x'))) {
+  /**
+    Modifier that applies classes. Usage:
+
+    ```hbs
+    <div {{css-transition name="example"}}>
     <p>Hello world</p>
-  </div>
-  ```
+    </div>
+    ```
 
-  @class CssTransitionModifier
-  @argument {Function} [didTransitionIn]
-  @argument {Function} [didTransitionOut]
-  @public
-*/
-export default class CssTransitionModifier extends Modifier {
-  clone = null;
-  parentElement = null;
-  nextElementSibling = null;
-  installed = false;
-
-  /**
-   * @property el
-   * @type {(HTMLElement|undefined)}
-   * @private
-   * @readonly
+    @class CssTransitionModifier
+    @argument {Function} [didTransitionIn]
+    @argument {Function} [didTransitionOut]
+    @public
    */
-  get el() {
-    return this.clone || this.element;
-  }
+  class CssTransitionModifier extends Modifier {
+    element = null;
+    clone = null;
+    parentElement = null;
+    nextElementSibling = null;
+    installed = false;
+    finishedTransitionIn = false;
+    isEnabled = true;
+    parentSelector;
 
-  /**
-   * @property transitionName
-   * @type {(String|undefined)}
-   * @private
-   * @readonly
-   */
-  get transitionName() {
-    return this.args.positional[0] || this.args.named.name;
-  }
-
-  /**
-   * @property enterClass
-   * @type {(String|undefined)}
-   * @private
-   * @readonly
-   */
-  get enterClass() {
-    return (
-      this.args.named.enterClass ||
-      (this.transitionName && `${this.transitionName}-enter`)
-    );
-  }
-
-  /**
-   * @property enterActiveClass
-   * @type {(String|undefined)}
-   * @private
-   * @readonly
-   */
-  get enterActiveClass() {
-    return (
-      this.args.named.enterActiveClass ||
-      (this.transitionName && `${this.transitionName}-enter-active`)
-    );
-  }
-
-  /**
-   * @property enterToClass
-   * @type {(String|undefined)}
-   * @private
-   * @readonly
-   */
-  get enterToClass() {
-    return (
-      this.args.named.enterToClass ||
-      (this.transitionName && `${this.transitionName}-enter-to`)
-    );
-  }
-
-  /**
-   * @property leaveClass
-   * @type {(String|undefined)}
-   * @private
-   * @readonly
-   */
-  get leaveClass() {
-    return (
-      this.args.named.leaveClass ||
-      (this.transitionName && `${this.transitionName}-leave`)
-    );
-  }
-
-  /**
-   * @property leaveActiveClass
-   * @type {(String|undefined)}
-   * @private
-   * @readonly
-   */
-  get leaveActiveClass() {
-    return (
-      this.args.named.leaveActiveClass ||
-      (this.transitionName && `${this.transitionName}-leave-active`)
-    );
-  }
-
-  /**
-   * @property leaveToClass
-   * @type {(String|undefined)}
-   * @private
-   * @readonly
-   */
-  get leaveToClass() {
-    return (
-      this.args.named.leaveToClass ||
-      (this.transitionName && `${this.transitionName}-leave-to`)
-    );
-  }
-
-  didInstall() {
-    if (this.args.named.isEnabled === false) {
-      return;
+    /**
+     * @property el
+     * @type {(HTMLElement|undefined)}
+     * @private
+     * @readonly
+     */
+    get el() {
+      return this.clone || this.element;
     }
 
-    let el = this.getElementToClone();
-    this.parentElement = el.parentElement;
-    this.nextElementSibling = el.nextElementSibling;
+    /**
+     * @property didTransitionIn
+     * @type {(Function|undefined)}
+     * @private
+     */
+    didTransitionIn;
 
-    this.guardedRun(this.transitionIn);
-  }
+    /**
+     * @property didTransitionOut
+     * @type {(Function|undefined)}
+     * @private
+     */
+    didTransitionOut;
 
-  willRemove() {
-    if (this.args.named.isEnabled === false || !this.installed) {
-      return;
-    }
+    /**
+     * @property transitionName
+     * @type {(String|undefined)}
+     * @private
+     */
+    transitionName;
 
-    this.guardedRun(this.transitionOut);
-  }
+    /**
+     * @property enterClass
+     * @type {(String|undefined)}
+     * @private
+     */
+    enterClass;
 
-  /**
-   * Adds a clone to the parentElement so it can be transitioned out
-   *
-   * @private
-   * @method addClone
-   */
-  addClone() {
-    let original = this.getElementToClone();
-    let parentElement = original.parentElement || this.parentElement;
-    let nextElementSibling =
-      original.nextElementSibling || this.nextElementSibling;
+    /**
+     * @property enterActiveClass
+     * @type {(String|undefined)}
+     * @private
+     */
+    enterActiveClass;
 
-    if (
-      nextElementSibling &&
-      nextElementSibling.parentElement !== parentElement
-    ) {
-      nextElementSibling = null;
-    }
+    /**
+     * @property enterToClass
+     * @type {(String|undefined)}
+     * @private
+     */
+    enterToClass;
 
-    let clone = original.cloneNode(true);
+    /**
+     * @property leaveClass
+     * @type {(String|undefined)}
+     * @private
+     */
+    leaveClass;
 
-    clone.setAttribute('id', `${original.id}_clone`);
+    /**
+     * @property leaveActiveClass
+     * @type {(String|undefined)}
+     * @private
+     */
+    leaveActiveClass;
 
-    parentElement.insertBefore(clone, nextElementSibling);
+    /**
+     * @property leaveToClass
+     * @type {(String|undefined)}
+     * @private
+     */
+    leaveToClass;
 
-    this.clone = clone;
-  }
+    constructor(owner, args) {
+      super(owner, args);
 
-  /**
-   * Finds the correct element to clone. If `parentSelector` is present, we will
-   * use the closest parent element that matches that selector. Otherwise we use
-   * the element's immediate parentElement directly.
-   *
-   * @private
-   * @method getElementToClone
-   */
-  getElementToClone() {
-    if (this.args.named.parentSelector) {
-      return this.element.closest(this.args.named.parentSelector);
-    } else {
-      return this.element;
-    }
-  }
+      registerDestructor(this, () => {
+        if (this.isEnabled === false || !this.finishedTransitionIn) {
+          return;
+        }
 
-  /**
-   * Removes the clone from the parentElement
-   *
-   * @private
-   * @method removeClone
-   */
-  removeClone() {
-    if (this.clone.isConnected && this.clone.parentNode !== null) {
-      this.clone.parentNode.removeChild(this.clone);
-    }
-  }
-
-  *transitionIn() {
-    if (this.enterClass) {
-      yield* this.transition({
-        className: this.enterClass,
-        activeClassName: this.enterActiveClass,
-        toClassName: this.enterToClass,
+        this.guardedRun(this.transitionOut);
       });
+    }
 
-      if (this.args.named.didTransitionIn) {
-        this.args.named.didTransitionIn();
+    modify(element, positional, named) {
+      this.element = element;
+
+      this.setupProperties(positional, named);
+
+      if (named.isEnabled === false || this.installed) {
+        return;
+      }
+
+      this.installed = true;
+      let el = this.getElementToClone();
+      this.parentElement = el.parentElement;
+      this.nextElementSibling = el.nextElementSibling;
+
+      this.guardedRun(this.transitionIn);
+    }
+
+    setupProperties(positional, named) {
+      this.isEnabled = named.isEnabled !== false;
+      this.transitionName = positional[0] || named.name;
+      this.didTransitionIn = named.didTransitionIn;
+      this.didTransitionOut = named.didTransitionOut;
+      this.parentSelector = named.parentSelector;
+
+      this.enterClass =
+        named.enterClass ||
+        (this.transitionName && `${this.transitionName}-enter`);
+
+      this.enterActiveClass =
+        named.enterActiveClass ||
+        (this.transitionName && `${this.transitionName}-enter-active`);
+
+      this.enterToClass =
+        named.enterToClass ||
+        (this.transitionName && `${this.transitionName}-enter-to`);
+
+      this.leaveClass =
+        named.leaveClass ||
+        (this.transitionName && `${this.transitionName}-leave`);
+
+      this.leaveActiveClass =
+        named.leaveActiveClass ||
+        (this.transitionName && `${this.transitionName}-leave-active`);
+
+      this.leaveToClass =
+        named.leaveToClass ||
+        (this.transitionName && `${this.transitionName}-leave-to`);
+    }
+
+    /**
+     * Adds a clone to the parentElement, so it can be transitioned out.
+     *
+     * @private
+     * @method addClone
+     */
+    addClone() {
+      let original = this.getElementToClone();
+      let parentElement = original.parentElement || this.parentElement;
+      let nextElementSibling =
+        original.nextElementSibling || this.nextElementSibling;
+
+      if (
+        nextElementSibling &&
+        nextElementSibling.parentElement !== parentElement
+      ) {
+        nextElementSibling = null;
+      }
+
+      let clone = original.cloneNode(true);
+
+      clone.setAttribute('id', `${original.id}_clone`);
+
+      parentElement.insertBefore(clone, nextElementSibling);
+
+      this.clone = clone;
+    }
+
+    /**
+     * Finds the correct element to clone. If `parentSelector` is present, we will
+     * use the closest parent element that matches that selector. Otherwise, we use
+     * the element's immediate parentElement directly.
+     *
+     * @private
+     * @method getElementToClone
+     */
+    getElementToClone() {
+      if (this.parentSelector) {
+        return this.element.closest(this.parentSelector);
+      } else {
+        return this.element;
       }
     }
 
-    this.installed = true;
-  }
+    /**
+     * Removes the clone from the parentElement
+     *
+     * @private
+     * @method removeClone
+     */
+    removeClone() {
+      if (this.clone.isConnected && this.clone.parentNode !== null) {
+        this.clone.parentNode.removeChild(this.clone);
+      }
+    }
 
-  *transitionOut() {
-    if (this.leaveClass) {
-      // We can't stop ember from removing the element
-      // so we clone the element to animate it out
-      this.addClone();
+    *transitionIn() {
+      if (this.enterClass) {
+        yield* this.transition({
+          className: this.enterClass,
+          activeClassName: this.enterActiveClass,
+          toClassName: this.enterToClass,
+        });
+
+        if (this.didTransitionIn) {
+          this.didTransitionIn();
+        }
+      }
+
+      this.finishedTransitionIn = true;
+    }
+
+    *transitionOut() {
+      if (this.leaveClass) {
+        // We can't stop ember from removing the element
+        // so we clone the element to animate it out
+        this.addClone();
+
+        yield nextTick();
+
+        yield* this.transition({
+          className: this.leaveClass,
+          activeClassName: this.leaveActiveClass,
+          toClassName: this.leaveToClass,
+        });
+
+        this.removeClone();
+
+        if (this.didTransitionOut) {
+          this.didTransitionOut();
+        }
+
+        this.clone = null;
+      }
+    }
+
+    /**
+     * Transitions the element.
+     *
+     * @private
+     * @method transition
+     * @param {Object} args
+     * @param {String} args.className the class representing the starting state
+     * @param {String} args.activeClassName the class applied during the entire transition. This class can be used to define the duration, delay and easing curve.
+     * @param {String} args.toClassName the class representing the finished state
+     * @return {Generator}
+     */
+    *transition({ className, activeClassName, toClassName }) {
+      let element = this.el;
+
+      // add first class right away
+      this.addClass(className);
+      this.addClass(activeClassName);
 
       yield nextTick();
 
-      yield* this.transition({
-        className: this.leaveClass,
-        activeClassName: this.leaveActiveClass,
-        toClassName: this.leaveToClass,
-      });
+      // This is for to force a repaint,
+      // which is necessary in order to transition styles when adding a class name.
+      element.scrollTop;
 
-      this.removeClone();
+      // after repaint
+      this.addClass(toClassName);
+      this.removeClass(className);
 
-      if (this.args.named.didTransitionOut) {
-        this.args.named.didTransitionOut();
+      // wait for ember to apply classes
+      // set timeout for animation end
+      yield sleep(computeTimeout(element) || 0);
+
+      this.removeClass(toClassName);
+      this.removeClass(activeClassName);
+    }
+
+    /**
+     * Add classNames to el.
+     *
+     * @private
+     * @method addClass
+     * @param {String} className
+     */
+    addClass(className) {
+      this.el.classList.add(...className.trim().split(/\s+/));
+    }
+
+    /**
+     * Remove classNames from el.
+     *
+     * @private
+     * @method removeClass
+     * @param {String} className
+     */
+    removeClass(className) {
+      this.el.classList.remove(...className.trim().split(/\s+/));
+    }
+
+    async guardedRun(f, ...args) {
+      let gen = f.call(this, ...args);
+      let isDone = false;
+
+      // stop if the function doesn't have anything else to yield
+      // or if the element is no longer present
+      while (!isDone && this.el) {
+        let { value, done } = gen.next();
+        isDone = done;
+        await value;
+      }
+    }
+  }
+
+  modifier = CssTransitionModifier;
+} else {
+  modifier = class extends Modifier {
+    clone = null;
+    parentElement = null;
+    nextElementSibling = null;
+    installed = false;
+
+    /**
+     * @property el
+     * @type {(HTMLElement|undefined)}
+     * @private
+     * @readonly
+     */
+    get el() {
+      return this.clone || this.element;
+    }
+
+    /**
+     * @property transitionName
+     * @type {(String|undefined)}
+     * @private
+     * @readonly
+     */
+    get transitionName() {
+      return this.args.positional[0] || this.args.named.name;
+    }
+
+    /**
+     * @property enterClass
+     * @type {(String|undefined)}
+     * @private
+     * @readonly
+     */
+    get enterClass() {
+      return (
+        this.args.named.enterClass ||
+        (this.transitionName && `${this.transitionName}-enter`)
+      );
+    }
+
+    /**
+     * @property enterActiveClass
+     * @type {(String|undefined)}
+     * @private
+     * @readonly
+     */
+    get enterActiveClass() {
+      return (
+        this.args.named.enterActiveClass ||
+        (this.transitionName && `${this.transitionName}-enter-active`)
+      );
+    }
+
+    /**
+     * @property enterToClass
+     * @type {(String|undefined)}
+     * @private
+     * @readonly
+     */
+    get enterToClass() {
+      return (
+        this.args.named.enterToClass ||
+        (this.transitionName && `${this.transitionName}-enter-to`)
+      );
+    }
+
+    /**
+     * @property leaveClass
+     * @type {(String|undefined)}
+     * @private
+     * @readonly
+     */
+    get leaveClass() {
+      return (
+        this.args.named.leaveClass ||
+        (this.transitionName && `${this.transitionName}-leave`)
+      );
+    }
+
+    /**
+     * @property leaveActiveClass
+     * @type {(String|undefined)}
+     * @private
+     * @readonly
+     */
+    get leaveActiveClass() {
+      return (
+        this.args.named.leaveActiveClass ||
+        (this.transitionName && `${this.transitionName}-leave-active`)
+      );
+    }
+
+    /**
+     * @property leaveToClass
+     * @type {(String|undefined)}
+     * @private
+     * @readonly
+     */
+    get leaveToClass() {
+      return (
+        this.args.named.leaveToClass ||
+        (this.transitionName && `${this.transitionName}-leave-to`)
+      );
+    }
+
+    didInstall() {
+      if (this.args.named.isEnabled === false) {
+        return;
       }
 
-      this.clone = null;
+      let el = this.getElementToClone();
+      this.parentElement = el.parentElement;
+      this.nextElementSibling = el.nextElementSibling;
+
+      this.guardedRun(this.transitionIn);
     }
-  }
 
-  /**
-   * Transitions the element.
-   *
-   * @private
-   * @method transition
-   * @param {Object} args
-   * @param {String} args.className the class representing the starting state
-   * @param {String} args.activeClassName the class applied during the entire transition. This class can be used to define the duration, delay and easing curve.
-   * @param {String} args.toClassName the class representing the finished state
-   * @return {Generator}
-   */
-  *transition({ className, activeClassName, toClassName }) {
-    let element = this.el;
+    willRemove() {
+      if (this.args.named.isEnabled === false || !this.installed) {
+        return;
+      }
 
-    // add first class right away
-    this.addClass(className);
-    this.addClass(activeClassName);
-
-    yield nextTick();
-
-    // This is for to force a repaint,
-    // which is necessary in order to transition styles when adding a class name.
-    element.scrollTop;
-
-    // after repaint
-    this.addClass(toClassName);
-    this.removeClass(className);
-
-    // wait for ember to apply classes
-    // set timeout for animation end
-    yield sleep(computeTimeout(element) || 0);
-
-    this.removeClass(toClassName);
-    this.removeClass(activeClassName);
-  }
-
-  /**
-   * Add classNames to el.
-   *
-   * @private
-   * @method addClass
-   * @param {String} classNames
-   */
-  addClass(className) {
-    this.el.classList.add(...className.trim().split(/\s+/));
-  }
-
-  /**
-   * Remove classNames from el.
-   *
-   * @private
-   * @method removeClass
-   * @param {String} classNames
-   */
-  removeClass(className) {
-    this.el.classList.remove(...className.trim().split(/\s+/));
-  }
-
-  async guardedRun(f, ...args) {
-    let gen = f.call(this, ...args);
-    let isDone = false;
-
-    // stop if the function doesn't have anything else to yield
-    // or if the element is no longer present
-    while (!isDone && this.el) {
-      let { value, done } = gen.next();
-      isDone = done;
-      await value;
+      this.guardedRun(this.transitionOut);
     }
-  }
+
+    /**
+     * Adds a clone to the parentElement so it can be transitioned out
+     *
+     * @private
+     * @method addClone
+     */
+    addClone() {
+      let original = this.getElementToClone();
+      let parentElement = original.parentElement || this.parentElement;
+      let nextElementSibling =
+        original.nextElementSibling || this.nextElementSibling;
+
+      if (
+        nextElementSibling &&
+        nextElementSibling.parentElement !== parentElement
+      ) {
+        nextElementSibling = null;
+      }
+
+      let clone = original.cloneNode(true);
+
+      clone.setAttribute('id', `${original.id}_clone`);
+
+      parentElement.insertBefore(clone, nextElementSibling);
+
+      this.clone = clone;
+    }
+
+    /**
+     * Finds the correct element to clone. If `parentSelector` is present, we will
+     * use the closest parent element that matches that selector. Otherwise we use
+     * the element's immediate parentElement directly.
+     *
+     * @private
+     * @method getElementToClone
+     */
+    getElementToClone() {
+      if (this.args.named.parentSelector) {
+        return this.element.closest(this.args.named.parentSelector);
+      } else {
+        return this.element;
+      }
+    }
+
+    /**
+     * Removes the clone from the parentElement
+     *
+     * @private
+     * @method removeClone
+     */
+    removeClone() {
+      if (this.clone.isConnected && this.clone.parentNode !== null) {
+        this.clone.parentNode.removeChild(this.clone);
+      }
+    }
+
+    *transitionIn() {
+      if (this.enterClass) {
+        yield* this.transition({
+          className: this.enterClass,
+          activeClassName: this.enterActiveClass,
+          toClassName: this.enterToClass,
+        });
+
+        if (this.args.named.didTransitionIn) {
+          this.args.named.didTransitionIn();
+        }
+      }
+
+      this.installed = true;
+    }
+
+    *transitionOut() {
+      if (this.leaveClass) {
+        // We can't stop ember from removing the element
+        // so we clone the element to animate it out
+        this.addClone();
+
+        yield nextTick();
+
+        yield* this.transition({
+          className: this.leaveClass,
+          activeClassName: this.leaveActiveClass,
+          toClassName: this.leaveToClass,
+        });
+
+        this.removeClone();
+
+        if (this.args.named.didTransitionOut) {
+          this.args.named.didTransitionOut();
+        }
+
+        this.clone = null;
+      }
+    }
+
+    /**
+     * Transitions the element.
+     *
+     * @private
+     * @method transition
+     * @param {Object} args
+     * @param {String} args.className the class representing the starting state
+     * @param {String} args.activeClassName the class applied during the entire transition. This class can be used to define the duration, delay and easing curve.
+     * @param {String} args.toClassName the class representing the finished state
+     * @return {Generator}
+     */
+    *transition({ className, activeClassName, toClassName }) {
+      let element = this.el;
+
+      // add first class right away
+      this.addClass(className);
+      this.addClass(activeClassName);
+
+      yield nextTick();
+
+      // This is for to force a repaint,
+      // which is necessary in order to transition styles when adding a class name.
+      element.scrollTop;
+
+      // after repaint
+      this.addClass(toClassName);
+      this.removeClass(className);
+
+      // wait for ember to apply classes
+      // set timeout for animation end
+      yield sleep(computeTimeout(element) || 0);
+
+      this.removeClass(toClassName);
+      this.removeClass(activeClassName);
+    }
+
+    /**
+     * Add classNames to el.
+     *
+     * @private
+     * @method addClass
+     * @param {String} className
+     */
+    addClass(className) {
+      this.el.classList.add(...className.trim().split(/\s+/));
+    }
+
+    /**
+     * Remove classNames from el.
+     *
+     * @private
+     * @method removeClass
+     * @param {String} className
+     */
+    removeClass(className) {
+      this.el.classList.remove(...className.trim().split(/\s+/));
+    }
+
+    async guardedRun(f, ...args) {
+      let gen = f.call(this, ...args);
+      let isDone = false;
+
+      // stop if the function doesn't have anything else to yield
+      // or if the element is no longer present
+      while (!isDone && this.el) {
+        let { value, done } = gen.next();
+        isDone = done;
+        await value;
+      }
+    }
+  };
 }
+
+export default modifier;

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -2,7 +2,6 @@
   "name": "test-app",
   "version": "4.0.0",
   "private": true,
-  "private": true,
   "description": "Ember implementation of CSS Transitions. Just like ng-animate and react animation but for Ember.",
   "keywords": [
     "animation"
@@ -27,9 +26,6 @@
     "test": "npm-run-all lint test:*",
     "test:ember": "ember test",
     "test:ember-compatibility": "ember try:each"
-  },
-  "resolutions": {
-    "babel-import-util": "1.1.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.17.0",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -2,6 +2,7 @@
   "name": "test-app",
   "version": "4.0.0",
   "private": true,
+  "private": true,
   "description": "Ember implementation of CSS Transitions. Just like ng-animate and react animation but for Ember.",
   "keywords": [
     "animation"
@@ -26,6 +27,9 @@
     "test": "npm-run-all lint test:*",
     "test:ember": "ember test",
     "test:ember-compatibility": "ember try:each"
+  },
+  "resolutions": {
+    "babel-import-util": "1.1.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7146,7 +7146,7 @@ ember-modifier-manager-polyfill@^1.2.0:
     ember-cli-version-checker "^2.1.2"
     ember-compatibility-helpers "^1.2.0"
 
-"ember-modifier@^2.1.2 || ^3.1.0":
+"ember-modifier@^2.1.2 || ^3.1.0", "ember-modifier@^2.1.2 || ^3.1.0 || ^4.0.0":
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-3.2.7.tgz#f2d35b7c867cbfc549e1acd8d8903c5ecd02ea4b"
   integrity sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3325,9 +3325,9 @@ babel-import-util@^0.2.0:
   integrity sha512-CtWYYHU/MgK88rxMrLfkD356dApswtR/kWZ/c6JifG1m10e7tBBrs/366dFzWMAoqYmG5/JSh+94tUSpIwh+ag==
 
 babel-import-util@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/babel-import-util/-/babel-import-util-1.1.0.tgz#4156b16ef090c4f0d3cdb869ff799202f24aeb93"
-  integrity sha512-sfzgAiJsUT1es9yrHAuJZuJfBkkOE7Og6rovAIwK/gNJX6MjDfWTprbPngdJZTd5ye4F3FvpvpQmvKXObRzVYA==
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/babel-import-util/-/babel-import-util-1.2.2.tgz#1027560e143a4a68b1758e71d4fadc661614e495"
+  integrity sha512-8HgkHWt5WawRFukO30TuaL9EiDUOdvyKtDwLma4uBNeUSDbOO0/hiPfavrOWxSS6J6TKXfukWHZ3wiqZhJ8ONQ==
 
 babel-loader@^8.0.6:
   version "8.2.3"


### PR DESCRIPTION
Follows [`ember-modifier` v4 migration guide](https://github.com/ember-modifier/ember-modifier/blob/v3.2.5/MIGRATIONS.md#function-based-modifiers)
to remove deprecations added in v3.2.0 and makes addon compatible with 4.x.

Also introduces `ember-modifier-scenarios` job to verify compat in CI.

closes #86