### PR TITLE
Replace use of RSVP with native Promise

### DIFF
--- a/addon/src/utils/transition-utils.js
+++ b/addon/src/utils/transition-utils.js
@@ -1,8 +1,7 @@
 import { later } from '@ember/runloop';
-import { Promise } from 'rsvp';
 
 /**
- * Function that returns a promise that resolves after after DOM changes
+ * Function that returns a promise that resolves after DOM changes
  * have been flushed and after a browser repaint.
  *
  * @function nextTick


### PR DESCRIPTION
There is no real reason we need RSVP in these use cases.
This change is similar to https://github.com/ember-animation/ember-animated/pull/457.

Ideal long-term fix would need to be done in embroider (see https://github.com/embroider-build/embroider/issues/1195) as this allows library authors to easily shoot in the foot.