### PR TITLE
Add opt-in integration with @ember/test-waiters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: "Tests"
+  lint:
+    name: "Lint"
     runs-on: ubuntu-latest
 
     steps:
@@ -35,13 +35,38 @@ jobs:
         run: yarn lint
         working-directory: test-app
 
+  test:
+    name: "Tests (useTestWaiters = ${{ matrix.test-waiters }})"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: 'lint'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        test-waiters:
+          - true
+          - false
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+          cache: yarn
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+
       - name: Run Tests
-        run: yarn test:ember
+        run: USE_TEST_WAITERS=${{ matrix.test-waiters }} yarn test:ember
         working-directory: test-app
 
   floating:
     name: "Floating Dependencies"
     runs-on: ubuntu-latest
+    needs: 'lint'
 
     steps:
       - uses: actions/checkout@v3
@@ -61,6 +86,7 @@ jobs:
   test-docs:
     name: "Docs"
     runs-on: ubuntu-latest
+    needs: 'lint'
 
     steps:
       - uses: actions/checkout@v3
@@ -84,7 +110,7 @@ jobs:
   try-scenarios:
     name: ${{ matrix.try-scenario }}
     runs-on: ubuntu-latest
-    needs: 'test'
+    needs: 'lint'
 
     strategy:
       fail-fast: false
@@ -119,7 +145,7 @@ jobs:
     name: ${{ matrix.ember-modifier-scenario }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: 'test'
+    needs: 'lint'
 
     strategy:
       fail-fast: false

--- a/ember-css-transitions/package.json
+++ b/ember-css-transitions/package.json
@@ -37,6 +37,7 @@
     "lint:js:fix": "eslint . --fix"
   },
   "dependencies": {
+    "@ember/test-waiters": "^3.0.0",
     "@embroider/addon-shim": "^1.8.3",
     "ember-modifier": "^2.1.2 || ^3.1.0 || ^4.0.0"
   },

--- a/ember-css-transitions/src/modifiers/css-transition.js
+++ b/ember-css-transitions/src/modifiers/css-transition.js
@@ -1,8 +1,24 @@
 import Modifier from 'ember-modifier';
 import { registerDestructor } from '@ember/destroyable';
-import { macroCondition, dependencySatisfies } from '@embroider/macros';
+import {
+  dependencySatisfies,
+  getOwnConfig,
+  macroCondition,
+} from '@embroider/macros';
+import { buildWaiter } from '@ember/test-waiters';
 
 import { nextTick, sleep, computeTimeout } from '../utils/transition-utils';
+
+const waiter = getOwnConfig().useTestWaiters
+  ? buildWaiter('ember-css-transitions')
+  : {
+      beginAsync() {
+        /* fake */
+      },
+      endAsync() {
+        /* fake */
+      },
+    };
 
 let modifier;
 
@@ -320,6 +336,8 @@ if (macroCondition(dependencySatisfies('ember-modifier', '>=3.2.0 || 4.x'))) {
     }
 
     async guardedRun(f, ...args) {
+      const token = waiter.beginAsync();
+
       let gen = f.call(this, ...args);
       let isDone = false;
 
@@ -330,6 +348,8 @@ if (macroCondition(dependencySatisfies('ember-modifier', '>=3.2.0 || 4.x'))) {
         isDone = done;
         await value;
       }
+
+      waiter.endAsync(token);
     }
   }
 
@@ -614,6 +634,8 @@ if (macroCondition(dependencySatisfies('ember-modifier', '>=3.2.0 || 4.x'))) {
     }
 
     async guardedRun(f, ...args) {
+      const token = waiter.beginAsync();
+
       let gen = f.call(this, ...args);
       let isDone = false;
 
@@ -624,6 +646,8 @@ if (macroCondition(dependencySatisfies('ember-modifier', '>=3.2.0 || 4.x'))) {
         isDone = done;
         await value;
       }
+
+      waiter.endAsync(token);
     }
   };
 }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "url": "https://github.com/miguelcobain/ember-css-transitions.git"
   },
   "workspaces": [
-    "ember-css-transitions",
     "docs",
+    "ember-css-transitions",
     "test-app"
   ],
   "scripts": {
@@ -19,6 +19,10 @@
     "@release-it-plugins/lerna-changelog": "^5.0.0",
     "@release-it-plugins/workspaces": "^3.2.0",
     "release-it": "^15.4.2"
+  },
+  "volta": {
+    "node": "14.21.1",
+    "yarn": "1.22.19"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
@@ -59,9 +63,5 @@
       "tokenRef": "GITHUB_AUTH"
     },
     "npm": false
-  },
-  "volta": {
-    "node": "14.21.1",
-    "yarn": "1.22.19"
   }
 }

--- a/test-app/ember-cli-build.js
+++ b/test-app/ember-cli-build.js
@@ -7,6 +7,13 @@ module.exports = function (defaults) {
     autoImport: {
       watchDependencies: ['ember-css-transitions'],
     },
+    '@embroider/macros': {
+      setConfig: {
+        'ember-css-transitions': {
+          useTestWaiters: process.env.USE_TEST_WAITERS !== 'false',
+        },
+      },
+    },
   });
 
   // Use `app.import` to add additional libraries to the generated

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -28,6 +28,7 @@
     "@babel/core": "^7.20.2",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.8.1",
+    "@embroider/macros": "^1.8.3",
     "@embroider/test-setup": "^1.6.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",


### PR DESCRIPTION
There are use cases when you may want css-transitions to integrate with test helpers provided by `@ember/test-helpers` package. This is not possible today out of the box.

This PR allows users to specify `useTestWaiters` config option in `ember-cli-build.js` file like so:

```js
  const app = new EmberApp(defaults, {
    '@embroider/macros': {
      setConfig: {
        'ember-css-transitions': {
          useTestWaiters: true
        }
      }
    },
    // other options
  });
```