### PR TITLE
Handle no ownConfig scenario

### DIFF
--- a/ember-css-transitions/src/modifiers/css-transition.js
+++ b/ember-css-transitions/src/modifiers/css-transition.js
@@ -9,7 +9,7 @@ import { buildWaiter } from '@ember/test-waiters';
 
 import { nextTick, sleep, computeTimeout } from '../utils/transition-utils';
 
-const waiter = getOwnConfig().useTestWaiters
+const waiter = (getOwnConfig() || {}).useTestWaiters
   ? buildWaiter('ember-css-transitions')
   : {
       beginAsync() {


### PR DESCRIPTION
If no config was provided via `setConfig`, addon should not fail and assume test waiters integration should be not used.