### PR TITLE
fix: Include /types in package exports

### DIFF
--- a/ember-css-transitions/package.json
+++ b/ember-css-transitions/package.json
@@ -12,7 +12,10 @@
   "author": "Petter Kjelkenes <kjelkenes@gmail.com>",
   "exports": {
     ".": "./dist/addon-main.js",
-    "./*": "./dist/*",
+    "./*": {
+      "types": "./types/*.d.ts",
+      "default": "./dist/*.js"
+    },
     "./addon-main.js": "./addon-main.js"
   },
   "typesVersions": {


### PR DESCRIPTION
This adds `./types/*` to the `exports` in `package.json`.

I don't totally understand what this does but I ran into an issue when trying to import the `CssTransitionsRegistry` like in the README example for "TypeScript Usage" after configuring TypeScript to use `"bundler"` for `"moduleResolution"`.

I enabled `"bundler"` `"moduleResolution"` after seeing [a comment from @gossi suggesting that as a fix for another issue](https://github.com/buschtoens/ember-link/issues/777#issuecomment-1649255712). Apparently `"bundler"` is also now set by the [latest version of `@tsconfig/ember`](https://github.com/tsconfig/bases/blob/53d80ed4a9ece800ffca9774c4e63cef3ce6ab38/bases/ember.json#L13) and so others will likely run into this as well.

This seems to also work when `"moduleResolution"` is not set to `"bundler"` but again, I'm not really sure what this is doing and/or why it's needed.

References

- https://github.com/buschtoens/ember-link/issues/777#issuecomment-1649255712 
- https://github.com/tsconfig/bases/blob/53d80ed4a9ece800ffca9774c4e63cef3ce6ab38/bases/ember.json#L13