### PR TITLE
Make utility functions importable

### DIFF
--- a/ember-css-transitions/rollup.config.mjs
+++ b/ember-css-transitions/rollup.config.mjs
@@ -17,7 +17,7 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['modifiers/**/*.js', 'index.js']),
+    addon.publicEntrypoints(['modifiers/**/*.js', 'utils/**/*.js', 'index.js']),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but

--- a/ember-css-transitions/types/utils/transition-utils.d.ts
+++ b/ember-css-transitions/types/utils/transition-utils.d.ts
@@ -1,0 +1,27 @@
+/**
+ * Function that returns a promise that resolves after `ms` milliseconds
+ *
+ * @function sleep
+ * @param {number} ms number of milliseconds to wait
+ * @return {Promise<void>} the promise
+ */
+export function sleep(ms: number): Promise<void>;
+
+/**
+ * Computes the time a css animation will take.
+ * Uses `getComputedStyle` to get durations and delays.
+ *
+ * @function computeTimeout
+ * @param {Element} element element used calculate the animation duration based on `getComputedStyle`
+ * @return {number} the calculated animation duration + delay
+ */
+export function computeTimeout(element: Element): number;
+
+/**
+ * Function that returns a promise that resolves after DOM changes
+ * have been flushed and after a browser repaint.
+ *
+ * @function nextTick
+ * @return {Promise<void>} the promise
+ */
+export function nextTick(): Promise<void>;

--- a/test-app/tests/unit/utils/transition-utils-test.ts
+++ b/test-app/tests/unit/utils/transition-utils-test.ts
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit';
+import {
+  computeTimeout,
+  nextTick,
+  sleep,
+} from 'ember-css-transitions/utils/transition-utils';
+
+module('Unit | Utility | transition-utils', function () {
+  test('nextTick exists', function (assert) {
+    assert.strictEqual(typeof nextTick, 'function');
+  });
+
+  test('sleep exists', function (assert) {
+    assert.strictEqual(typeof sleep, 'function');
+  });
+
+  test('computeTimeout exists', function (assert) {
+    assert.strictEqual(typeof computeTimeout, 'function');
+  });
+});


### PR DESCRIPTION
My attempt to fix #120.

This PR adds the utils folder to the public entry points in the rollup config file.
I also added tests that import the functions and made a type file for the utility functions.